### PR TITLE
Update Readme structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,3 @@
-# FR_Arduino_Reference
-
-# Index
-## B
-BNO055
-- [bno_intro.ino](https://github.com/frstray/FR_Arduino_Reference/blob/main/sensors/bno_intro.ino)
-## I
-I2C
-- [bno_intro.ino](https://github.com/frstray/FR_Arduino_Reference/blob/main/sensors/bno_intro.ino)
-## L
-LED
-- [rgb_blink.ino](https://github.com/frstray/FR_Arduino_Reference/blob/main/Basic_Arduino_Concepts/rgb_blink.ino)
-## P
-Pointer 
-- [intro_to_pointers.ino](https://github.com/frstray/FR_Arduino_Reference/blob/main/Basic_Arduino_Concepts/intro_to_pointers.ino)
-## R
-RGB
-- [rgb_blink.ino](https://github.com/frstray/FR_Arduino_Reference/blob/main/Basic_Arduino_Concepts/rgb_blink.ino)
-## S
-Struct
-- [how_to_struct.ino](https://github.com/frstray/FR_Arduino_Reference/blob/main/Basic_Arduino_Concepts/how_to_struct.ino)
+# Forest's Arduino Reference
+This repository is my personal reference to all things [Arduino](https://docs.arduino.cc/).<br>
+Looking for a specific topic? Checkout the [index](https://github.com/frstray/FR_Arduino_Reference/blob/frstray-patch-1/topic_index.md). 

--- a/topic_index.md
+++ b/topic_index.md
@@ -1,0 +1,21 @@
+This index tells you where to find information about different topics within this repository. 
+
+# Index
+## B
+BNO055
+- [bno_intro.ino](https://github.com/frstray/FR_Arduino_Reference/blob/main/sensors/bno_intro.ino)
+## I
+I2C
+- [bno_intro.ino](https://github.com/frstray/FR_Arduino_Reference/blob/main/sensors/bno_intro.ino)
+## L
+LED
+- [rgb_blink.ino](https://github.com/frstray/FR_Arduino_Reference/blob/main/Basic_Arduino_Concepts/rgb_blink.ino)
+## P
+Pointer 
+- [intro_to_pointers.ino](https://github.com/frstray/FR_Arduino_Reference/blob/main/Basic_Arduino_Concepts/intro_to_pointers.ino)
+## R
+RGB
+- [rgb_blink.ino](https://github.com/frstray/FR_Arduino_Reference/blob/main/Basic_Arduino_Concepts/rgb_blink.ino)
+## S
+Struct
+- [how_to_struct.ino](https://github.com/frstray/FR_Arduino_Reference/blob/main/Basic_Arduino_Concepts/how_to_struct.ino)


### PR DESCRIPTION
Have the main readme file link out to the index instead of having the index being the first docs displayed